### PR TITLE
Replace JCenter repo with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
[Bintray and JCenter are now deprecated and becoming read-only](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), so it is not recommended to use it any more if possible. Replace usage of JCenter with Maven Central instead.