### PR TITLE
fix: git throws 128 error

### DIFF
--- a/src/main/java/com/widen/versioning/VersionGenerator.java
+++ b/src/main/java/com/widen/versioning/VersionGenerator.java
@@ -58,7 +58,7 @@ public class VersionGenerator {
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .directory(projectDir);
-            processBuilder.environment().put("GIT_DIR", projectDir.getPath() + "/.git");
+            processBuilder.environment().put("GIT_DIR", projectDir.getPath());
 
             Process process = processBuilder.start();
             String output = IOUtils.toString(process.getInputStream(), Charset.forName("UTF-8"));


### PR DESCRIPTION
#3 Maybe this is an easier fix than adding some variable, since from what I can tell being inside the `.git` folder is not required to call `git describe`